### PR TITLE
IDEA delegates a build task to gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,10 @@
+import javax.xml.bind.JAXBContext
+import javax.xml.bind.Marshaller
+import javax.xml.bind.Unmarshaller
+import java.nio.file.Paths
+import groovy.xml.XmlUtil
+import groovy.xml.StreamingMarkupBuilder
+
 buildscript {
     dependencies {
         classpath 'com.google.guava:guava:28.1-jre'
@@ -65,23 +72,6 @@ dependencies {
     annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
 }
 
-idea {
-    project {
-        // Set the version control system
-        // to Git for this project.
-        // All values IntelliJ IDEA supports
-        // can be used. E.g. Subversion, Mercurial.
-        vcs = 'Git'
-
-        languageLevel = '1.8'
-    }
-
-    module {
-        downloadJavadoc = true
-        downloadSources = false
-    }
-}
-
 apply from: 'gradle/jacoco.gradle'
 apply from: 'gradle/spotbugs.gradle'
 apply from: 'gradle/configure.gradle'
@@ -89,3 +79,4 @@ apply from: 'gradle/protobuf.gradle'
 apply from: 'gradle/checkstyle.gradle'
 apply from: 'gradle/corfu.gradle'
 apply from: 'gradle/java.gradle'
+apply from: 'gradle/idea.gradle'

--- a/gradle/idea.gradle
+++ b/gradle/idea.gradle
@@ -27,9 +27,8 @@ idea {
  * Delegate running builds and tests to gradle.
  * Manual settings: preferences -> Build, Execution, Deployment -> gradle -> [build and run using | Run tests using]
  *
- * This settings make IDEA using gradle instead of native builder,
- * which makes it consistent with gradle build and solves a problem
- * when IDEA messed up with properties files in resource directory
+ * These settings make IDEA using Gradle instead of a native builder, which makes it consistent with Gradle build
+ * and solves a problem when IDEA messed up with properties files in the resource directory
  */
 task ideaGradleRunner {
     doLast {

--- a/gradle/idea.gradle
+++ b/gradle/idea.gradle
@@ -1,6 +1,8 @@
 import groovy.xml.XmlUtil
-
 import java.nio.file.Paths
+import java.io.File
+import groovy.util.XmlParser
+import groovy.xml.*
 
 idea {
     project {
@@ -32,20 +34,33 @@ idea {
  */
 task ideaGradleRunner {
     doLast {
-        File gradleSettings = Paths.get(".idea", "gradle.xml").toFile()
+        File gradleSettings = Paths.get(".idea", "gradle1.xml").toFile()
+        if (!gradleSettings.exists()) {
+            return
+        }
 
-        def xml = new XmlParser().parse(gradleSettings)
-        def gradleTag = xml.'*'
+        def xml = new XmlParser(false, false).parse(gradleSettings)
+        Node gradleTag = xml.'*'
                 .find { node -> node.@name == 'GradleSettings' }
                 .option
-                .GradleProjectSettings
+                .GradleProjectSettings[0]
 
-        gradleTag.'*'.find { node -> node.@name == 'delegatedBuild' }.@value = true
-        gradleTag.'*'.find { node -> node.@name == 'testRunner' }.@value = 'GRADLE'
+        createOrModifyOptionTag(gradleTag, 'delegatedBuild', 'true')
+        createOrModifyOptionTag(gradleTag, 'testRunner', 'GRADLE')
 
         gradleSettings.withWriter { outWriter ->
             XmlUtil.serialize(xml, outWriter)
         }
+    }
+}
+
+static def createOrModifyOptionTag(Node gradleTag, String nameAttr, String valueAttr) {
+    def tag = gradleTag.'*'.find { node -> node.@name == nameAttr }
+    if(tag){
+        tag.@value = valueAttr
+    } else {
+        //create a node
+        gradleTag.appendNode(new QName("option"), ['name': nameAttr, 'value': valueAttr])
     }
 }
 

--- a/gradle/idea.gradle
+++ b/gradle/idea.gradle
@@ -1,0 +1,58 @@
+import groovy.xml.XmlUtil
+
+import java.nio.file.Paths
+
+idea {
+    project {
+        // Set the version control system
+        // to Git for this project.
+        // All values IntelliJ IDEA supports
+        // can be used. E.g. Subversion, Mercurial.
+        vcs = 'Git'
+
+        languageLevel = '1.8'
+    }
+
+    module {
+        downloadJavadoc = true
+        downloadSources = false
+
+        inheritOutputDirs = false
+        outputDir = compileJava.destinationDir
+        testOutputDir = compileTestJava.destinationDir
+    }
+}
+
+/**
+ * Delegate running builds and tests to gradle.
+ * Manual settings: preferences -> Build, Execution, Deployment -> gradle -> [build and run using | Run tests using]
+ *
+ * This settings make IDEA using gradle instead of native builder,
+ * which makes it consistent with gradle build and solves a problem
+ * when IDEA messed up with properties files in resource directory
+ */
+task ideaGradleRunner {
+    doLast {
+        File gradleSettings = Paths.get(".idea", "gradle.xml").toFile()
+
+        def xml = new XmlParser().parse(gradleSettings)
+        def gradleTag = xml.'*'
+                .find { node -> node.@name == 'GradleSettings' }
+                .option
+                .GradleProjectSettings
+
+        gradleTag.'*'.find { node -> node.@name == 'delegatedBuild' }.@value = true
+        gradleTag.'*'.find { node -> node.@name == 'testRunner' }.@value = 'GRADLE'
+
+        gradleSettings.withWriter { outWriter ->
+            XmlUtil.serialize(xml, outWriter)
+        }
+    }
+}
+
+/**
+ * Whenever processResources executed it also delegates a build task to the gradle
+ */
+processResources {
+    dependsOn("ideaGradleRunner")
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Thu Jan 23 21:33:25 PST 2020
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1-bin.zip
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
These settings make IDEA using Gradle instead of a native builder, which makes it consistent with Gradle build and solves a problem when IDEA messed up with properties files in the resource directory