### PR TITLE
Kibana index-pattern - get rid of 'fields' in a json dto

### DIFF
--- a/cloud/infrastructure/kibana/kibana-tools/src/main/kotlin/org/corfudb/cloud/infrastructure/kibana/tools/Json.kt
+++ b/cloud/infrastructure/kibana/kibana-tools/src/main/kotlin/org/corfudb/cloud/infrastructure/kibana/tools/Json.kt
@@ -20,7 +20,7 @@ data class IndexPatternCreation(
         val migrationVersion: JsonNode
 )
 
-data class IndexPatternAttributes(var title: String, val timeFieldName: String, val fields: String)
+data class IndexPatternAttributes(var title: String, val timeFieldName: String)
 
 data class Reference(var id: String, val name: String, val type: String)
 


### PR DESCRIPTION
Kibana index-pattern - get rid of 'fields' in a JSON dto