### PR TITLE
Migrate corfudb-cloud to JDK 25

### DIFF
--- a/.github/workflows/publish-universe-artifacts.yml
+++ b/.github/workflows/publish-universe-artifacts.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'corretto'
-          java-version: '21'
+          java-version: '25'
           check-latest: true
           cache-dependency-path: '**/pom.xml'
 

--- a/.github/workflows/pull_request_benchmarks.yml
+++ b/.github/workflows/pull_request_benchmarks.yml
@@ -22,7 +22,7 @@ jobs:
       uses: actions/setup-java@v4
       with:
         distribution: 'corretto'
-        java-version: '21'
+        java-version: '25'
         check-latest: true
         cache-dependency-path: '**/pom.xml'
 

--- a/.github/workflows/pull_request_universe.yml
+++ b/.github/workflows/pull_request_universe.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/setup-java@v4
       with:
         distribution: 'corretto'
-        java-version: '21'
+        java-version: '25'
         check-latest: true
         cache-dependency-path: '**/pom.xml'
 

--- a/.github/workflows/run_benchmarks.yml
+++ b/.github/workflows/run_benchmarks.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'corretto'
-          java-version: '21'
+          java-version: '25'
           check-latest: true
           cache-dependency-path: '**/pom.xml'
 

--- a/benchmarks/Dockerfile
+++ b/benchmarks/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:21-bullseye
+FROM eclipse-temurin:25-jdk-noble
 
 RUN apt-get update && apt-get install -y iputils-ping
 

--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -7,9 +7,9 @@ buildscript {
 plugins {
     java
     idea
-    id("com.google.protobuf") version "0.9.3"
+    id("com.google.protobuf") version "0.9.6"
     id("com.google.osdetector") version "1.6.2"
-    id("io.freefair.lombok") version "8.12.1"
+    id("io.freefair.lombok") version "9.2.0"
     id("checkstyle")
     id("jacoco")
     id("maven-publish")

--- a/benchmarks/gradle/wrapper/gradle-wrapper.properties
+++ b/benchmarks/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Thu Jan 23 21:33:25 PST 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/cloud/corfu/corfu-client-example/Dockerfile
+++ b/cloud/corfu/corfu-client-example/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:21-bullseye
+FROM eclipse-temurin:25-jdk-noble
 
 ADD ./build/libs/corfu-runtime-client-example.jar /app/
 

--- a/cloud/corfu/corfu-client-example/gradle/wrapper/gradle-wrapper.properties
+++ b/cloud/corfu/corfu-client-example/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Thu Jan 23 21:33:25 PST 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/cloud/infrastructure/gradle/wrapper/gradle-wrapper.properties
+++ b/cloud/infrastructure/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Thu Jan 23 21:33:25 PST 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/cloud/infrastructure/integration-tools/Dockerfile
+++ b/cloud/infrastructure/integration-tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:21-bullseye
+FROM eclipse-temurin:25-jdk-noble
 
 RUN apt update \
     && apt install -y ca-certificates curl \

--- a/cloud/infrastructure/integration-tools/build.gradle.kts
+++ b/cloud/infrastructure/integration-tools/build.gradle.kts
@@ -2,7 +2,7 @@ import java.nio.charset.StandardCharsets
 
 plugins {
     kotlin("jvm") version "1.3.71"
-    id("com.palantir.docker") version "0.36.0"
+    id("com.palantir.docker") version "0.37.0"
 }
 
 repositories {

--- a/cloud/infrastructure/kibana/kibana-tools/Dockerfile
+++ b/cloud/infrastructure/kibana/kibana-tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:21-bullseye
+FROM eclipse-temurin:25-jdk-noble
 
 ADD ./lib /app/lib/
 ADD ./*.jar /app/

--- a/cloud/infrastructure/kibana/kibana-tools/build.gradle.kts
+++ b/cloud/infrastructure/kibana/kibana-tools/build.gradle.kts
@@ -3,7 +3,7 @@ import java.nio.charset.StandardCharsets
 plugins {
     kotlin("jvm") version "1.3.71"
     kotlin("plugin.serialization") version "1.3.71"
-    id("com.palantir.docker") version "0.36.0"
+    id("com.palantir.docker") version "0.37.0"
 }
 
 val gradleScriptsDir: String = project.rootDir.parentFile.parent

--- a/gradle/idea.gradle
+++ b/gradle/idea.gradle
@@ -1,14 +1,14 @@
 import groovy.xml.XmlUtil
+import groovy.xml.XmlParser
+import groovy.namespace.QName
 import java.nio.file.Paths
 import java.io.File
-import groovy.util.XmlParser
-import groovy.xml.*
 
 idea {
     module {
         inheritOutputDirs = false
-        outputDir = compileJava.destinationDir
-        testOutputDir = compileTestJava.destinationDir
+        outputDir = compileJava.destinationDirectory.asFile.get()
+        testOutputDir = compileTestJava.destinationDirectory.asFile.get()
     }
 }
 

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -1,8 +1,8 @@
 group = 'org.corfudb'
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
+    sourceCompatibility = JavaVersion.VERSION_25
+    targetCompatibility = JavaVersion.VERSION_25
 
     withJavadocJar()
     withSourcesJar()
@@ -13,6 +13,7 @@ dependencies {
 
     testImplementation "org.assertj:assertj-core:${assertjVersion}"
     testImplementation "org.junit.jupiter:junit-jupiter-engine:${junitVersion}"
+    testRuntimeOnly "org.junit.platform:junit-platform-launcher:1.5.2"
 }
 
 /**
@@ -22,7 +23,15 @@ dependencies {
  */
 test {
     maxHeapSize("4096m")
-    jvmArgs("--add-opens=java.base/java.net=ALL-UNNAMED")
+    jvmArgs(
+        "--add-opens=java.base/java.net=ALL-UNNAMED",
+        "--add-opens=java.base/java.lang=ALL-UNNAMED",
+        "--add-opens=java.base/java.util=ALL-UNNAMED",
+        "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED",
+        "--add-opens=java.base/java.io=ALL-UNNAMED",
+        "--add-opens=java.management/sun.management=ALL-UNNAMED",
+        "--add-opens=jdk.attach/sun.tools.attach=ALL-UNNAMED"
+    )
 
     useJUnitPlatform {
         def tags = System.getProperty('tags', '')

--- a/gradle/universe.gradle
+++ b/gradle/universe.gradle
@@ -1,13 +1,13 @@
 task deployment(type: JavaExec) {
     group = 'corfu'
 
-    main = 'org.corfudb.universe.test.management.Deployment'
+    mainClass.set('org.corfudb.universe.test.management.Deployment')
     classpath = sourceSets.main.runtimeClasspath
 }
 
 task shutdown(type: JavaExec) {
     group = 'corfu'
 
-    main = 'org.corfudb.universe.test.management.Shutdown'
+    mainClass.set('org.corfudb.universe.test.management.Shutdown')
     classpath = sourceSets.main.runtimeClasspath
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Thu Jan 23 21:33:25 PST 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:21-bullseye
+FROM eclipse-temurin:25-jdk-noble
 
 ADD ./ /universe-tests
 WORKDIR /universe-tests/tests

--- a/tests/build.gradle.kts
+++ b/tests/build.gradle.kts
@@ -7,12 +7,12 @@ buildscript {
 plugins {
     java
     idea
-    id("com.google.protobuf") version "0.9.3"
+    id("com.google.protobuf") version "0.9.6"
     id("com.google.osdetector") version "1.6.2"
-    id("io.freefair.lombok") version "8.12.1"
+    id("io.freefair.lombok") version "9.2.0"
     id("checkstyle")
     id("jacoco")
-    id("com.palantir.docker") version "0.36.0"
+    id("com.palantir.docker") version "0.37.0"
 }
 
 val gradleScriptsDir: String = project.rootDir.parent

--- a/tests/gradle/wrapper/gradle-wrapper.properties
+++ b/tests/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Thu Jan 23 21:33:25 PST 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/tests/settings.gradle.kts
+++ b/tests/settings.gradle.kts
@@ -1,3 +1,17 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+    resolutionStrategy {
+        eachPlugin {
+            if (requested.id.id == "com.palantir.docker") {
+                useModule("com.palantir.gradle.docker:gradle-docker:${requested.version}")
+            }
+        }
+    }
+}
+
 rootProject.name = "corfu-universe-tests"
 
 includeBuild("../universe")

--- a/universe/gradle/wrapper/gradle-wrapper.properties
+++ b/universe/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Thu Jan 23 21:33:25 PST 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/universe/universe-core/build.gradle.kts
+++ b/universe/universe-core/build.gradle.kts
@@ -6,7 +6,7 @@ buildscript {
 
 plugins {
     java
-    id("io.freefair.lombok") version "8.12.1"
+    id("io.freefair.lombok") version "9.2.0"
     id("checkstyle")
     id("jacoco")
     id("maven-publish")

--- a/universe/universe-core/src/main/java/org/corfudb/universe/infrastructure/docker/universe/FakeDns.java
+++ b/universe/universe-core/src/main/java/org/corfudb/universe/infrastructure/docker/universe/FakeDns.java
@@ -9,6 +9,7 @@ import java.net.spi.InetAddressResolver;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
+
 /**
  * Fake DNS resolver which allows our tests to work well even though we use
  * strange loopback IP addresses (127.x.y.z) with no corresponding reverse
@@ -49,7 +50,9 @@ public class FakeDns {
      * Install the fake DNS resolver into the Java runtime.
      */
     public synchronized FakeDns install() {
-        if (installed) return this;
+        if (installed) {
+            return this;
+        }
         try {
             installDns();
         } catch (Exception e) {

--- a/universe/universe-infrastructure/build.gradle.kts
+++ b/universe/universe-infrastructure/build.gradle.kts
@@ -6,7 +6,7 @@ buildscript {
 
 plugins {
     java
-    id("io.freefair.lombok") version "8.12.1"
+    id("io.freefair.lombok") version "9.2.0"
     id("checkstyle")
     id("jacoco")
     id("maven-publish")


### PR DESCRIPTION
## Changes Made

### Gradle Wrapper (6 files)
- Upgraded Gradle from 8.10 to 9.1.0 across all subprojects
  (root, universe, tests, benchmarks, cloud/infrastructure,
  cloud/corfu/corfu-client-example).
  Gradle 9.1.0 is required for JDK 25 support (8.10 only supports up to Java 23).

### Java Compilation (gradle/java.gradle)
- sourceCompatibility and targetCompatibility updated from VERSION_21
  to VERSION_25.
- Added --add-opens JVM flags for JDK 25's stricter module encapsulation:
  java.base/java.net, java.base/java.lang, java.base/java.util,
  java.base/java.lang.reflect, java.base/java.io,
  java.management/sun.management, jdk.attach/sun.tools.attach.
- Added testRuntimeOnly dependency on junit-platform-launcher:1.5.2
  (required by Gradle 9.x - JUnit Platform launcher must be explicitly
  on the test runtime classpath).

### Groovy/Gradle 9.x API Compatibility (gradle/idea.gradle)
- groovy.util.XmlParser -> groovy.xml.XmlParser (moved in Groovy 4.x)
- QName import changed from groovy.xml.* to groovy.namespace.QName
- compileJava.destinationDir -> compileJava.destinationDirectory.asFile.get()
  (destinationDir removed in Gradle 9.x)

### Gradle 9.x API Compatibility (gradle/universe.gradle)
- JavaExec.main -> JavaExec.mainClass.set() (main property removed in
  Gradle 9.x) for deployment and shutdown tasks.

### Lombok Plugin Upgrade (4 files)
- io.freefair.lombok upgraded from 8.12.1 to 9.2.0 in:
  universe/universe-core/build.gradle.kts
  universe/universe-infrastructure/build.gradle.kts
  tests/build.gradle.kts
  benchmarks/build.gradle.kts
  (8.12.1 is incompatible with Gradle 9.x; 9.2.0 bundles
  Lombok 1.18.40+ which supports JDK 25)

### Protobuf Plugin Upgrade (2 files)
- com.google.protobuf upgraded from 0.9.3 to 0.9.6 in:
  benchmarks/build.gradle.kts
  tests/build.gradle.kts
  (0.9.3 uses Configuration.fileCollection() which was removed in Gradle 9.x)

### Palantir Docker Plugin Upgrade (3 files)
- com.palantir.docker upgraded from 0.36.0 to 0.37.0 in:
  tests/build.gradle.kts
  cloud/infrastructure/integration-tools/build.gradle.kts
  cloud/infrastructure/kibana/kibana-tools/build.gradle.kts
  (0.36.0 uses ImmutableAttributesFactory internal API removed in Gradle 9.x)
- Added pluginManagement block with Maven Central repository and
  resolutionStrategy in tests/settings.gradle.kts (0.37.0 is published
  to Maven Central but not the Gradle Plugin Portal).

### Checkstyle Fix (FakeDns.java)
- Added missing blank line before class declaration
- Added braces to single-line if statement

### GitHub Actions Workflows (4 files)
- pull_request_universe.yml: java-version 21 -> 25
- pull_request_benchmarks.yml: java-version 21 -> 25
- publish-universe-artifacts.yml: java-version 21 -> 25
- run_benchmarks.yml: java-version 21 -> 25

### Dockerfiles (5 files)
- tests/Dockerfile: openjdk:21-bullseye -> eclipse-temurin:25-jdk-noble
- benchmarks/Dockerfile: openjdk:21-bullseye -> eclipse-temurin:25-jdk-noble
- cloud/corfu/corfu-client-example/Dockerfile: openjdk:21-bullseye -> eclipse-temurin:25-jdk-noble
- cloud/infrastructure/integration-tools/Dockerfile: openjdk:21-bullseye -> eclipse-temurin:25-jdk-noble
- cloud/infrastructure/kibana/kibana-tools/Dockerfile: openjdk:21-bullseye -> eclipse-temurin:25-jdk-noble

Note: Also migrated from deprecated openjdk Docker images to eclipse-temurin
(Adoptium), which is the recommended OpenJDK distribution.

Verified locally with JDK 25.0.2:
- ./gradlew check passes in universe/
- ./gradlew check passes in benchmarks/
- ./gradlew compileJava compileTestJava passes in tests/
  (tests/check has pre-existing checkstyle and Docker integration test
  failures unrelated to JDK migration)